### PR TITLE
Access wrapped component with withRef.

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -290,11 +290,14 @@ export default function ui(key, opts = {}) {
           }, {}) || {};
         }
 
+        // To access the wrapped instance, you need to specify { withRef: true } in opts.
+        const { withRef } = opts;
+
         render() {
           return (
             <WrappedComponent
               { ...this.props }
-              ref="WrappedComponentInstance"
+              ref={ withRef ? 'WrappedComponentInstance' : undefined}
               uiKey={ this.key }
               uiPath={ this.uiPath }
               ui={ this.mergeUIProps() }


### PR DESCRIPTION
To access the wrapped instance, you need to specify { withRef: true } in opts.